### PR TITLE
Fix versionId for AES TR-31 header

### DIFF
--- a/key-import-export/tr34/import_app/import_tr31_raw_key_to_apc.py
+++ b/key-import-export/tr34/import_app/import_tr31_raw_key_to_apc.py
@@ -11,7 +11,7 @@ import argparse
 
 def constructTr31Header(algo,exportMode,keyType,modeOfUse):
 
-    versionID = 'B' #version D is supported also but it requires kbpk to be AES as well
+    versionID = 'D' if algo == 'A' else 'B'
     length = '9999' #this library will overwrite it with the correct value
 
     header = versionID + length + keyType + algo + modeOfUse + "00" + exportMode + "0000"


### PR DESCRIPTION
*Issue #, if available:*
TR-31 header is not using the right `versionId` for AES key

*Description of changes:*
Using key algorithm param to choose `versionId` for AES. Changes are backward compatible. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
