### PR TITLE
Fix APC mappings for GQ, FC, FE in payShield command mapping

### DIFF
--- a/migration_guidance/payshield-command-mapping.md
+++ b/migration_guidance/payshield-command-mapping.md
@@ -276,8 +276,8 @@ This document maps Thales payShield HSM commands to their equivalent AWS Payment
 | Supported | Description | Command | APC Equivalent | Notes |
 |-----------|-------------|---------|----------------|-------|
 | Y | Import ZPK (replaced by A6) | FA | Import Key | |
-| N/A | Import keys (replaced by A6) | FC | Encrypt | |
-| N/A | Export Keys (replaced by A8) | FE | Encrypt | |
+| Y | Import keys (replaced by A6) | FC | Import Key | |
+| Y | Export Keys (replaced by A8) | FE | Export Key | |
 | Y | Generate PVK (replaced by A0) | FG | Create Key | |
 | Y | Create a ZEK or ZAK (replaced by A0) | FI | CreateKey | |
 | Y | Import a ZAK or ZEK (replaced by A6) | FK | Import Key | |
@@ -308,7 +308,7 @@ This document maps Thales payShield HSM commands to their equivalent AWS Payment
 |-----------|-------------|---------|----------------|-------|
 | N/A | Hash Data | GM | | Hash functions can be performed outside an HSM. |
 | Y | General Record Verify pin using IBM3624 | GO | VerifyPin | Input can be DUKPT protected pin. |
-| Y | General Record Verify pin using ABA/Visa PVV | GQ | TranslatePinData | Input can be DUKPT protected pin. |
+| Y | General Record Verify pin using ABA/Visa PVV | GQ | VerifyPin | Input can be DUKPT protected pin. |
 
 ### DUKPT MAC (GW)
 


### PR DESCRIPTION
These three rows map to an APC operation that contradicts the row's own description and its sibling rows in the same table:

- GQ ('Verify pin using ABA/Visa PVV') was mapped to TranslatePinData. A PVV check returns pass/fail, not a re-encrypted PIN block. Corrected to VerifyPin, matching the adjacent GO row ('Verify pin using IBM3624').
- FC ('Import keys, replaced by A6') and FE ('Export Keys, replaced by A8') were mapped to Encrypt. Corrected to Import Key / Export Key, matching the sibling FA/FK/FM rows and the 'replaced by A6/A8' notes (A6=Import Key, A8=Export Key). Supported flipped N/A->Y to match those siblings.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
