### PR TITLE
Add Windows support and named AWS profile option to raw key import scripts

### DIFF
--- a/key-import-export/ecdh/import_app/import_raw_key_ecdh.py
+++ b/key-import-export/ecdh/import_app/import_raw_key_ecdh.py
@@ -7,8 +7,12 @@ import sys
 import datetime
 import hashlib
 import hmac as hmac_module
-import termios
-import tty
+
+if sys.platform == 'win32':
+    import msvcrt
+else:
+    import termios
+    import tty
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.kdf.concatkdf import ConcatKDFHash
@@ -33,8 +37,35 @@ def _calculate_kcv(key_bytes: bytes, algo: str) -> str:
         return DES3.new(key_bytes, DES3.MODE_ECB).encrypt(bytes(DES3.block_size))[:3].hex().upper()
 
 
-def _read_masked_hex(prompt: str, optional: bool = False) -> str:
-    """Read hex from the terminal echoing '*' per character."""
+def _read_masked_hex_windows(prompt: str) -> list:
+    chars = []
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    while True:
+        ch = msvcrt.getwch()
+        if ch in ('\x00', '\xe0'):
+            msvcrt.getwch()  
+            continue
+        if ch in ('\r', '\n'):
+            sys.stdout.write('\n')
+            sys.stdout.flush()
+            break
+        elif ch == '\x08':
+            if chars:
+                chars.pop()
+                sys.stdout.write('\b \b')
+                sys.stdout.flush()
+        elif ch == '\x03':
+            sys.stdout.write('\n')
+            raise KeyboardInterrupt
+        else:
+            chars.append(ch)
+            sys.stdout.write('*')
+            sys.stdout.flush()
+    return chars
+
+
+def _read_masked_hex_posix(prompt: str) -> list:
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)
     chars = []
@@ -62,6 +93,15 @@ def _read_masked_hex(prompt: str, optional: bool = False) -> str:
                 sys.stdout.flush()
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+    return chars
+
+
+def _read_masked_hex(prompt: str, optional: bool = False) -> str:
+    """Read hex from the terminal echoing '*' per character."""
+    if sys.platform == 'win32':
+        chars = _read_masked_hex_windows(prompt)
+    else:
+        chars = _read_masked_hex_posix(prompt)
     return ''.join(chars).replace(' ', '')
 
 

--- a/key-import-export/rsa/import_app/import_raw_key_rsa.py
+++ b/key-import-export/rsa/import_app/import_raw_key_rsa.py
@@ -23,8 +23,12 @@ import botocore.session
 import secrets
 import argparse
 import sys
-import termios
-import tty
+
+if sys.platform == 'win32':
+    import msvcrt
+else:
+    import termios
+    import tty
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography import x509
@@ -161,8 +165,35 @@ def _calculate_kcv(key_bytes: bytes, algo: str) -> str:
         return DES3.new(key_bytes, DES3.MODE_ECB).encrypt(bytes(DES3.block_size))[:3].hex().upper()
 
 
-def _read_masked_hex(prompt: str, optional: bool = False) -> str:
-    """Read hex from the terminal echoing '*' per character. Returns stripped hex or '' if optional+empty."""
+def _read_masked_hex_windows(prompt: str) -> list:
+    chars = []
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    while True:
+        ch = msvcrt.getwch()
+        if ch in ('\x00', '\xe0'):
+            msvcrt.getwch() 
+            continue
+        if ch in ('\r', '\n'):
+            sys.stdout.write('\n')
+            sys.stdout.flush()
+            break
+        elif ch == '\x08':
+            if chars:
+                chars.pop()
+                sys.stdout.write('\b \b')
+                sys.stdout.flush()
+        elif ch == '\x03':
+            sys.stdout.write('\n')
+            raise KeyboardInterrupt
+        else:
+            chars.append(ch)
+            sys.stdout.write('*')
+            sys.stdout.flush()
+    return chars
+
+
+def _read_masked_hex_posix(prompt: str) -> list:
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)
     chars = []
@@ -190,6 +221,15 @@ def _read_masked_hex(prompt: str, optional: bool = False) -> str:
                 sys.stdout.flush()
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+    return chars
+
+
+def _read_masked_hex(prompt: str, optional: bool = False) -> str:
+    """Read hex from the terminal echoing '*' per character. Returns stripped hex or '' if optional+empty."""
+    if sys.platform == 'win32':
+        chars = _read_masked_hex_windows(prompt)
+    else:
+        chars = _read_masked_hex_posix(prompt)
     return ''.join(chars).replace(' ', '')
 
 

--- a/key-import-export/rsa/import_app/import_raw_key_rsa.py
+++ b/key-import-export/rsa/import_app/import_raw_key_rsa.py
@@ -19,7 +19,6 @@ The following api calls may be subject to https://aws.amazon.com/service-terms/ 
 Usage - python import_raw_key_rsa.py --action importclearkey --clearkey 6E46FE409DF704BCA75E7FF270B65E73 --algorithm A
 '''
 import boto3
-import botocore.session
 import secrets
 import argparse
 import sys
@@ -41,11 +40,8 @@ from Crypto.Cipher import DES3
 service = 'payment-cryptography'
 regionName = 'us-east-1'
 
-session = botocore.session.Session()
-config = session.get_scoped_config()
-
 def _get_region():
-    return config.get('region', regionName)
+    return boto3.Session().region_name or regionName
 
 def DeleteKey(keyArn):
     apc_client = boto3.client('payment-cryptography', region_name=_get_region())
@@ -342,12 +338,16 @@ if __name__ == '__main__':
                         help="Interactively prompt for key components with masked input and KCV display.")
     parser.add_argument("--algorithm", "-a", help="Key algorithm - (T)des or (A)es (default: T)", default="T", choices={"T","A"})
     parser.add_argument("--region", "-r", help="AWS region (optional, overrides profile/environment default)", default=None)
+    parser.add_argument("--profile", "-p", help="Named AWS profile to use for credentials (e.g. an AWS SSO profile). Overrides AWS_PROFILE/default.", default=None)
     parser.add_argument("--keytype", "-t", help="Key Type according to TR-31 norms. For instance K0, B0, etc", default="K0",
                         choices=['K0', 'K1', 'B0', 'D0', 'P0', 'E0', 'E3', 'E6', 'E1', 'C0', 'E2'])
     parser.add_argument("--modeofuse", "-m", help="Mode of use according to TR-31 norms. For instance B (encrypt/decrypt), X (derive key)", default="B",
                         choices=['B', 'X', 'N', 'E', 'D', 'C', 'G', 'V'])
 
     args = parser.parse_args()
+
+    if args.profile:
+        boto3.setup_default_session(profile_name=args.profile)
 
     if args.region:
         regionName = args.region

--- a/key-import-export/tr34/import_app/import_raw_key_tr34.py
+++ b/key-import-export/tr34/import_app/import_raw_key_tr34.py
@@ -13,8 +13,12 @@ import binascii
 import logging
 import argparse
 import sys
-import termios
-import tty
+
+if sys.platform == 'win32':
+    import msvcrt
+else:
+    import termios
+    import tty
 
 
 from Crypto.Hash import SHA256, CMAC
@@ -41,9 +45,35 @@ def _calculate_kcv(key_hex: str, algorithm: str) -> str:
         return DES3.new(key_bytes, DES3.MODE_ECB).encrypt(bytes(DES3.block_size))[:3].hex().upper()
 
 
-def _read_masked_hex(prompt: str, optional: bool = False) -> str:
-    """Read hex from the terminal, echoing '*' for each character typed.
-    Returns the stripped hex string, or '' if optional and the user presses Enter immediately."""
+def _read_masked_hex_windows(prompt: str) -> list:
+    chars = []
+    sys.stdout.write(prompt)
+    sys.stdout.flush()
+    while True:
+        ch = msvcrt.getwch()
+        if ch in ('\x00', '\xe0'):
+            msvcrt.getwch()  
+            continue
+        if ch in ('\r', '\n'):
+            sys.stdout.write('\n')
+            sys.stdout.flush()
+            break
+        elif ch == '\x08':  
+            if chars:
+                chars.pop()
+                sys.stdout.write('\b \b')
+                sys.stdout.flush()
+        elif ch == '\x03':  # Ctrl-C
+            sys.stdout.write('\n')
+            raise KeyboardInterrupt
+        else:
+            chars.append(ch)
+            sys.stdout.write('*')
+            sys.stdout.flush()
+    return chars
+
+
+def _read_masked_hex_posix(prompt: str) -> list:
     fd = sys.stdin.fileno()
     old_settings = termios.tcgetattr(fd)
     chars = []
@@ -72,6 +102,16 @@ def _read_masked_hex(prompt: str, optional: bool = False) -> str:
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
 
+    return chars
+
+
+def _read_masked_hex(prompt: str, optional: bool = False) -> str:
+    """Read hex from the terminal, echoing '*' for each character typed.
+    Returns the stripped hex string, or '' if optional and the user presses Enter immediately."""
+    if sys.platform == 'win32':
+        chars = _read_masked_hex_windows(prompt)
+    else:
+        chars = _read_masked_hex_posix(prompt)
     return ''.join(chars).replace(' ', '')
 
 


### PR DESCRIPTION
## Summary
- Adds Windows compatibility to the interactive masked-hex input in the RSA, ECDH, and TR-34 raw key import scripts, which previously relied on POSIX-only `termios`/`tty` and crashed on Windows.
- Adds a `--profile`/`-p` CLI argument to the RSA import script to select a named AWS profile (e.g. AWS SSO), and drops the `botocore.session` dependency in favor of `boto3.Session().region_name` for region resolution.